### PR TITLE
Add tofu fmt job

### DIFF
--- a/.github/workflows/infra-tests.yml
+++ b/.github/workflows/infra-tests.yml
@@ -9,8 +9,9 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      - uses: opentofu/setup-opentofu@v1
+
       - name: Run tofu fmt
-        uses: opentofu/setup-opentofu@v1
         run: | 
           tofu fmt
 

--- a/.github/workflows/infra-tests.yml
+++ b/.github/workflows/infra-tests.yml
@@ -11,7 +11,8 @@ jobs:
 
       - name: Run tofu fmt
         uses: opentofu/setup-opentofu@v1
-        run: tofu fmt
+        run: | 
+          tofu fmt
 
   terrascan:
     name: "Run Terrascan"

--- a/.github/workflows/infra-tests.yml
+++ b/.github/workflows/infra-tests.yml
@@ -3,6 +3,16 @@ name: Infrastructure Tests
 on: push
 
 jobs:
+  tofu_format:
+    name: "Run tofu fmt"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Run tofu fmt
+        uses: opentofu/setup-opentofu@v1
+        run: tofu fmt
+
   terrascan:
     name: "Run Terrascan"
     runs-on: ubuntu-latest

--- a/.github/workflows/infra-tests.yml
+++ b/.github/workflows/infra-tests.yml
@@ -15,6 +15,12 @@ jobs:
         run: | 
           tofu fmt
 
+      # Fail if formatting is needed
+      - name: Ensure code is formatted
+        run: |
+          git diff --exit-code
+        shell: bash
+
   terrascan:
     name: "Run Terrascan"
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ Solutions for the exercises from the [Fundamentals of DevOps Part 5: How to set 
 1. To help catch bugs, update the GitHub Actions workflow to run a JavaScript linter, such as [JSLint](https://www.jslint.com/) or [ESLint](https://eslint.org/), after every commit.
 2. To help keep your code consistently formatted, update the GitHub Actions workflow to run a code formatter, such as [Prettier](https://prettier.io/), after every commit.
 3. Run both the linter and code formatter as a precommit hook, so these checks run on your own computer before you can make a commit. You may wish to use the [pre-commit](https://pre-commit.com/) framework to manage your precommit hooks.
+4. Ensure that GitHub is authenticated to AWS and able to perform `tofu test` command for unit testing.
+5. To help keep your code consistently formatted, update the GitHub Actions workflow to run a code formatter, such as `tofu fmt`, after every commit.
 
 ## Adding ESLint step
 
@@ -63,3 +65,7 @@ To test the installed hooks and run against all files in the root of the project
 ```bash
 pre-commit run --all-files
 ```
+
+## Adding code formatter step for tofu
+
+To add code formatter step, use the `opentofu/setup-opentofu@v1` action and run `tofu fmt` command


### PR DESCRIPTION
To help keep your code consistently formatted, update the GitHub Actions workflow to run a code formatter, such as `tofu fmt`, after every commit.